### PR TITLE
Fix cursor showing in level

### DIFF
--- a/src/CursorManager.cpp
+++ b/src/CursorManager.cpp
@@ -65,9 +65,7 @@ void CursorManager::update() {
     if (auto* playLayer = PlayLayer::get()) {
         auto g = GameManager::get();
         if (!g->getGameVariable(GameVar::ShowCursor)) {
-            canShowInLevel = playLayer->m_hasCompletedLevel || 
-                playLayer->m_isPaused || 
-                !(g->getGameVariable(GameVar::LockCursor));   
+            canShowInLevel = playLayer->m_hasCompletedLevel || playLayer->m_isPaused;
         }
     }
 


### PR DESCRIPTION
i had to add empty platformmanager::init and ::resetcursor for it to compile, i assume they're currently intentionally gone so i didn't commit that