### PR TITLE
Fix macOS bug in which the cursor wouldnt hide automatically.

### DIFF
--- a/src/platform/PlatformMacOS.mm
+++ b/src/platform/PlatformMacOS.mm
@@ -4,96 +4,17 @@
 
 using namespace geode::prelude;
 
-// Hello index staff this single file is going to be the reason my mod gets rejected!!
-
-// static std::mutex s_mutex;
-// static std::condition_variable s_cv;
-// static siginfo_t* s_siginfo = nullptr;
-// static ucontext_t* s_context = nullptr;
-// static int s_signal = 0;
-
-// static void(*old_handler)(int);
-
 void PlatformManager::resetCursor() {
-    // if (this->m_previouslyShown != this->m_shown) {
-    //     if (this->m_shown) {
-    //         [NSCursor unhide];
-    //     } else {
-    //         [NSCursor hide];
-    //     }
-    //     this->m_previouslyShown = this->m_shown;
-    // }
+    if (this->m_previouslyShown != this->m_shown) {
+        if (this->m_shown) {
+            [NSCursor unhide];
+        } else {
+            [NSCursor hide];
+        }
+        this->m_previouslyShown = this->m_shown;
+    }
 }
-
-static void handlerThread() {
-    // log::info("Waiting in WaveCursor unhide thread");
-
-    // std::unique_lock<std::mutex> lock(s_mutex);
-    // s_cv.wait(lock, [] { return s_signal != 0; });
-
-    // // #ifdef GEODE_IS_INTEL_MAC
-    // // auto signalAddress = reinterpret_cast<void*>(s_context->uc_mcontext->__ss.__rip);
-    // // #else // m1
-    // // auto signalAddress = reinterpret_cast<void*>(s_context->uc_mcontext->__ss.__pc);
-    // // #endif
-    // log::info("WaveCursor handled an exception");
-    // [NSCursor unhide];
-
-    // old_handler(s_signal);
-    // s_signal = 0;
-}
-
-extern "C" void signalHandler(int signal, siginfo_t* signalInfo, void* vcontext) {
-
-	// auto context = reinterpret_cast<ucontext_t*>(vcontext);
-    
-    // {
-    //     std::unique_lock<std::mutex> lock(s_mutex);
-    //     s_signal = signal;
-    //     s_siginfo = signalInfo;
-    //     s_context = context;
-    // }
-
-    // s_cv.notify_all();
-    // std::unique_lock<std::mutex> lock(s_mutex);
-    // s_cv.wait(lock, [] { return s_signal == 0; });
-}
-
 
 void PlatformManager::init() {
-
     this->sharedInit();
-
-    // struct sigaction action;
-    // struct sigaction old;
-    // action.sa_sigaction = &signalHandler;
-    // action.sa_flags = SA_SIGINFO;
-    // sigemptyset(&action.sa_mask);
-    // sigemptyset(&old.sa_mask);
-
-    // // Copy all current sigactions to old
-    // sigaction(SIGSEGV, nullptr, &old);
-    // // sigaction(SIGINT, nullptr, &old);     // This one does not get tracked
-    // sigaction(SIGFPE, nullptr, &old);
-    // sigaction(SIGILL, nullptr, &old);
-    // sigaction(SIGTERM, nullptr, &old);
-    // sigaction(SIGABRT, nullptr, &old);
-    // sigaction(SIGBUS, nullptr, &old);
-
-    // // Copy the pointer from the old sigactions
-    // old_handler = old.sa_handler;
-
-    // log::info("handler + action {} {}", fmt::ptr(old.sa_handler), fmt::ptr(old.sa_sigaction));
-
-
-    // // Hook the sigactions!
-    // sigaction(SIGSEGV, &action, nullptr);
-    // sigaction(SIGINT, &action, nullptr);     
-    // sigaction(SIGFPE, &action, nullptr);
-    // sigaction(SIGILL, &action, nullptr);
-    // sigaction(SIGTERM, &action, nullptr);
-    // sigaction(SIGABRT, &action, nullptr);
-    // sigaction(SIGBUS, &action, nullptr);
-
-    // std::thread(&handlerThread).detach();
 }


### PR DESCRIPTION

This PR addresses the issue where the native macOS cursor was not being hidden while the custom WaveCursor was active.

The entire implementation of PlatformManager::resetCursor() in 
PlatformMacOS.mm was previously commented out. This seems to have been done accidentally when disabling a custom crash handler that violated Geode's Mod Index layout rules.

